### PR TITLE
Implement stripping LD directives from IPLD Node, and transforming IPLD to JSON-LD

### DIFF
--- a/ipld.go
+++ b/ipld.go
@@ -15,8 +15,7 @@ const (
 	CtxKey   = "@context" // the JSON-LD style context
 
 	CodecKey = "@codec" // used to determine which multicodec to use
-	LinkType = "mlink"  // a merkle-link type.
-	HashKey  = "hash"   // multihash in an mlink
+	LinkKey  = "mlink"  // key for merkle-links
 )
 
 // Node is an IPLD node. effectively, it is equivalent to a JSON-LD object.
@@ -98,16 +97,16 @@ func (l Link) Type() string {
 	return s
 }
 
-// HashStr returns the string value of l["hash"],
+// HashStr returns the string value of l["mlink"],
 // which is the value we use to store hashes.
-func (l Link) HashStr() string {
-	s, _ := l[HashKey].(string)
+func (l Link) LinkStr() string {
+	s, _ := l[LinkKey].(string)
 	return s
 }
 
 // Hash returns the multihash value of the link.
 func (l Link) Hash() (mh.Multihash, error) {
-	s := l.HashStr()
+	s := l.LinkStr()
 	if s == "" {
 		return nil, errors.New("no hash in link")
 	}
@@ -162,25 +161,21 @@ func Links(n Node) map[string]Link {
 // checks whether a value is a link. for now we assume that all links
 // follow:
 //
-//   { "@type"  : "mlink", "hash": "<multihash>" }
+//   { "mlink": "<multihash>" }
 func IsLink(v interface{}) bool {
 	vn, ok := v.(Node)
 	if !ok {
 		return false
 	}
 
-	ts, ok := vn[TypeKey].(string)
-	if !ok {
-		return false
-	}
-
-	return ts == LinkType
+	_, ok = vn[LinkKey].(string)
+	return ok;
 }
 
 // returns the link value of an object. for now we assume that all links
 // follow:
 //
-//   { "@type"  : "mlink", "hash": "<multihash>" }
+//   { "mlink": "<multihash>" }
 func LinkCast(v interface{}) (l Link, ok bool) {
 	if !IsLink(v) {
 		return

--- a/ipld_test.go
+++ b/ipld_test.go
@@ -8,7 +8,7 @@ import (
 
 type TC struct {
 	src   Node
-	links map[string]Link
+	links map[string]string
 	typ   string
 	ctx   interface{}
 }
@@ -25,66 +25,62 @@ func mmh(b58 string) mh.Multihash {
 
 func init() {
 	testCases = append(testCases, TC{
-		Node{
+		src: Node{
 			"foo": "bar",
 			"bar": []int{1, 2, 3},
 			"baz": Node{
-				"@type": "mlink",
-				"hash":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 			},
 		},
-		map[string]Link{
-			"baz": {"@type": "mlink", "hash": ("QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo")},
+		links: map[string]string{
+			"baz": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 		},
-		"",
-		nil,
-	})
-
-	testCases = append(testCases, TC{
-		Node{
-			"foo":      "bar",
-			"@type":    "commit",
+		typ: "",
+		ctx: nil,
+	}, TC{
+		src: Node{
 			"@context": "/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",
 			"baz": Node{
-				"@type": "mlink",
-				"hash":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 			},
 			"bazz": Node{
-				"@type": "mlink",
-				"hash":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 			},
 			"bar": Node{
-				"@type": "mlinkoo",
-				"hash":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
 			},
 			"bar2": Node{
 				"foo": Node{
-					"@type": "mlink",
-					"hash":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
 				},
 			},
 		},
-		map[string]Link{
-			"baz":      {"@type": "mlink", "hash": ("QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo")},
-			"bazz":     {"@type": "mlink", "hash": ("QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo")},
-			"bar2/foo": {"@type": "mlink", "hash": ("QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo")},
+		links: map[string]string{
+			"baz":      "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"bazz":     "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"bar":      "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
+			"bar2/foo": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
 		},
-		"",
-		"/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",
+		typ: "",
+		ctx: "/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",
 	})
 }
 
 func TestParsing(t *testing.T) {
 	for tci, tc := range testCases {
+		t.Logf("===== Test case #%d =====", tci)
 		doc := tc.src
 
 		// check links
 		links := doc.Links()
-		t.Log(links)
+		t.Logf("links: %#v", links)
+		if len(links) != len(tc.links) {
+			t.Errorf("links do not match, not the same number of links, expected %d, got %d", len(tc.links), len(links))
+		}
 		for k, l1 := range tc.links {
 			l2 := links[k]
-			if !l1.Equal(l2) {
-				t.Errorf("links do not match. %d/%s %s != %s", tci, k, l1, l2)
+			if l1 != l2["mlink"] {
+				t.Errorf("links do not match. %d/%#v %#v != %#v[mlink]", tci, k, l1, l2)
 			}
 		}
 	}

--- a/ipld_test.go
+++ b/ipld_test.go
@@ -31,9 +31,16 @@ func init() {
 			"baz": Node{
 				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 			},
+			"test": Node {
+				// This is not a link because mlink is not a string but a Node
+				"mlink": Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				},
+			},
 		},
 		links: map[string]string{
-			"baz": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"baz":        "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"test/mlink": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
 		},
 		typ: "",
 		ctx: nil,

--- a/ipld_test.go
+++ b/ipld_test.go
@@ -50,16 +50,19 @@ func init() {
 				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
 			},
 			"bar2": Node{
-				"foo": Node{
+				"@bar": Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
+				},
+				"\\@foo": Node{
 					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
 				},
 			},
 		},
 		links: map[string]string{
-			"baz":      "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
-			"bazz":     "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
-			"bar":      "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
-			"bar2/foo": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
+			"baz":       "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"bazz":      "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			"bar":       "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
+			"bar2/@foo": "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
 		},
 		typ: "",
 		ctx: "/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",

--- a/jsonld/ipld_test.go
+++ b/jsonld/ipld_test.go
@@ -1,0 +1,116 @@
+package jsonld
+
+import (
+	"testing"
+	"reflect"
+
+	ipld "github.com/ipfs/go-ipld"
+)
+
+type TC struct {
+	src    ipld.Node
+	jsonld ipld.Node
+}
+
+var testCases []TC
+
+func init() {
+	testCases = append(testCases, TC{
+		src: ipld.Node{
+			"foo": "bar",
+			"bar": []int{1, 2, 3},
+			"baz": ipld.Node{
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			},
+		},
+		jsonld: ipld.Node{
+			"foo": "bar",
+			"bar": []int{1, 2, 3},
+			"baz": ipld.Node{
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			},
+		},
+	}, TC{
+		src: ipld.Node{
+			"foo": "bar",
+			"bar": []int{1, 2, 3},
+			"@container": "@index",
+			"@index": "links",
+			"baz": ipld.Node{
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			},
+		},
+		jsonld: ipld.Node{
+			"links": ipld.Node{
+				"foo": "bar",
+				"bar": []int{1, 2, 3},
+				"baz": ipld.Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				},
+			},
+		},
+	}, TC{
+		src: ipld.Node{
+			"@attrs": ipld.Node{
+				"attr": "val",
+			},
+			"foo":        "bar",
+			"@index":     "files",
+			"@type":      "commit",
+			"@container": "@index",
+			"@context": "/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",
+			"baz": ipld.Node{
+				"foobar": "barfoo",
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			},
+			"\\@bazz": ipld.Node{
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+			},
+			"bar/ra\\b": ipld.Node{
+				"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
+			},
+			"bar": ipld.Node{
+				"@container": "@index",
+				"foo": ipld.Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPa",
+				},
+			},
+		},
+		jsonld: ipld.Node{
+			"attr": "val",
+			"@type": "commit",
+			"@context": "/ipfs/QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo/mdag",
+			"files": ipld.Node{
+				"foo":        "bar",
+				"baz": ipld.Node{
+					"foobar": "barfoo",
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				},
+				"@bazz": ipld.Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPo",
+				},
+				"bar/ra\\b": ipld.Node{
+					"mlink":  "QmZku7P7KeeHAnwMr6c4HveYfMzmtVinNXzibkiNbfDbPb",
+				},
+				"bar": ipld.Node{
+				},
+			},
+		},
+	})
+}
+
+func TestParsing(t *testing.T) {
+	for tci, tc := range testCases {
+		t.Logf("===== Test case #%d =====", tci)
+		doc := tc.src
+
+		// check JSON-LD mode
+		jsonld := ToLinkedDataAll(doc)
+		if !reflect.DeepEqual(tc.jsonld, jsonld) {
+			t.Errorf("JSON-LD version mismatch.\nGot:    %#v\nExpect: %#v", jsonld, tc.jsonld)
+		} else {
+			t.Log("JSON-LD version OK")
+		}
+
+	}
+}

--- a/jsonld/jsonld.go
+++ b/jsonld/jsonld.go
@@ -1,0 +1,75 @@
+package jsonld
+
+import(
+	ipld "github.com/ipfs/go-ipld"
+)
+
+const DefaultIndexName string = "@index"
+
+func ContainerIndexName(n ipld.Node, defaultval string) string {
+	var index_name string = defaultval
+
+	index_val, ok := n["@index"]
+	if str, is_string := index_val.(string); ok && is_string {
+		index_name = str
+	}
+
+	return index_name
+}
+
+// Like ToLinkedDataAll but on the root node only, for use in Walk
+func ToLinkedData(d ipld.Node) ipld.Node {
+	attrs, directives, _, index := ipld.ParseNodeIndex(d)
+	for k, v := range directives {
+		if k != "@container" {
+			attrs[k] = v
+		}
+	}
+	if len(index) > 0 {
+		index_name := ipld.ContainerIndexName(attrs, ipld.DefaultIndexName)
+		delete(attrs, "@index")
+		if index_name[0] != '@' {
+			attrs[index_name] = index
+		}
+	}
+	return attrs
+}
+
+// Reorganize the data to be valid JSON-LD. This expand custom IPLD directives
+// and unescape keys.
+//
+// The main processing now is to transform a IPLD data structure like this:
+//
+//	{
+//		"@container": "@index",
+//		"@index": "index-name",
+//		"@attrs": {
+//			"key": "value",
+//		},
+//		"index": { ... }
+//	}
+//
+// to:
+//
+//	{
+//		"key": "value",
+//		"index-name": {
+//			"index": { ... }
+//		}
+//	}
+//
+// In that case, it is good practice to define in the context the following
+// type (this function cannot change the context):
+//
+//	"index-name": { "@container": "@index" }
+//
+func ToLinkedDataAll(d ipld.Node) ipld.Node {
+	res, err := ipld.Transform(d, func(root, curr ipld.Node, path []string, err error) (ipld.Node, error) {
+		return ToLinkedData(curr), err
+	})
+	if err != nil {
+		panic(err) // should not happen
+	}
+	return res
+}
+

--- a/transform.go
+++ b/transform.go
@@ -1,0 +1,97 @@
+package ipld
+
+import (
+	"errors"
+	"strconv"
+	"path"
+)
+
+// TransformFunc is the type of the function called for each node visited by
+// Transform. The root argument is the node from which the Transform began. The
+// curr argument is the currently visited node. The path argument is the
+// traversal path, from root to curr.
+//
+// If there was a problem walking to curr, the err argument will describe the
+// problem and the function can decide how to handle the error (and Transform
+// _will not_ descend into any of the children of curr).
+//
+// TransformFunc may return a node, in which case the returned node will be used
+// for further traversal instead of the curr node.
+//
+// TransformFunc may return an error. If the error is the special SkipNode
+// error, the children of curr are skipped. All other errors halt processing
+// early.
+type TransformFunc func(root, curr Node, path []string, err error) (Node, error)
+
+// Transform traverses the given root node and all its children, calling
+// TransformFunc with every Node visited, including root. All errors that arise
+// while visiting nodes are passed to given TransformFunc. The traversing
+// algorithm is the same as the Walk function.
+//
+// Transform returns a node constructed from the different nodes returned by
+// TransformFunc.
+func Transform(root Node, transformFn TransformFunc) (Node, error) {
+	n, err := transform(root, root, nil, transformFn)
+	if node, ok := n.(Node); ok {
+		return node, err
+	} else {
+		return nil, err
+	}
+}
+
+// TransformFrom is just like Transform, but starts the Walk at given startFrom
+// sub-node.
+func TransformFrom(root Node, startFrom []string, transformFn TransformFunc) (interface{}, error) {
+	start := GetPathCmp(root, startFrom)
+	if start == nil {
+		return nil, errors.New("no descendant at " + path.Join(startFrom...))
+	}
+	return transform(root, start, startFrom, transformFn)
+}
+
+// transform is used to implement Transform
+func transform(root Node, curr interface{}, npath []string, transformFunc TransformFunc) (interface{}, error) {
+
+	if nc, ok := curr.(Node); ok { // it's a node!
+		// first, call user's WalkFunc.
+		newnode, err := transformFunc(root, nc, npath, nil)
+		res := Node{}
+		if err == SkipNode {
+			return newnode, nil // ok, let's skip this one.
+		} else if err != nil {
+			return nil, err // something bad happened, return early.
+		} else if newnode != nil {
+			nc = newnode
+		}
+
+		// then recurse.
+		for k, v := range nc {
+			n, err := transform(root, v, append(npath, k), transformFunc)
+			if err != nil {
+				return nil, err
+			} else if n != nil {
+				res[k] = n
+			}
+		}
+
+		return res, nil
+
+	} else if sc, ok := curr.([]interface{}); ok { // it's a slice!
+		res := []interface{}{}
+		for i, v := range sc {
+			k := strconv.Itoa(i)
+			n, err := transform(root, v, append(npath, k), transformFunc)
+			if err != nil {
+				return nil, err
+			} else if n != nil {
+				res = append(res, n)
+			}
+		}
+		return res, nil
+
+	} else { // it's just data.
+		// ignore it.
+	}
+	return curr, nil
+}
+

--- a/walk.go
+++ b/walk.go
@@ -76,6 +76,11 @@ func walk(root Node, curr interface{}, npath string, walkFunc WalkFunc) error {
 
 		// then recurse.
 		for k, v := range nc {
+			// Skip empty path components
+			if len(k) == 0 {
+				continue
+			}
+
 			// skip any keys which contain "/" in them.
 			// this is explicitly disallowed.
 			if strings.Contains(k, pathSep) {


### PR DESCRIPTION
This is a work in progress, but I wanted to have a place to discuss implementation

@jbenet, can you review the test case `ipld_test.go` and tell me if you think this goes in the right direction. Every test case has a few keys I want ti implement:
- json: the JSON derived from the original document stripped from LD directives
- links: subset of json obtained using the same algorithm but focused on searching links
- jsonld: (not implemented yet) IPLD node transformed to JSON-LD

At first, I wrote flattening algorithm without using the Walk function you created, and I then noticed that I should converge with your implementation. I modified the Walk function to allow preprocessing of Nodes (transforming the JSON tree). This would allow walking either the IPLD node unmodified, the node without the LD directives, or the LD model. You can walk the model using three methods.

I still have to write a few more test cases, and I plan to remove most of the code in `node_index.go` and put it somewhere else.
