### PR TITLE
Test that the JSON coding works

### DIFF
--- a/coding/Makefile
+++ b/coding/Makefile
@@ -1,0 +1,10 @@
+
+pb/bin/multicodec:
+	$(MAKE) -C pb bin/multicodec
+
+json.testfile: pb/bin/multicodec Makefile
+	: >$@
+	pb/bin/multicodec header /multicodec >>$@
+	pb/bin/multicodec header /json >>$@
+	echo '{"@codec":"/json","abc":{"mlink":"QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V"}}' >>$@
+

--- a/coding/coding.go
+++ b/coding/coding.go
@@ -3,7 +3,6 @@ package ipfsld
 import (
 	mc "github.com/jbenet/go-multicodec"
 	mccbor "github.com/jbenet/go-multicodec/cbor"
-	mcjson "github.com/jbenet/go-multicodec/json"
 	mcmux "github.com/jbenet/go-multicodec/mux"
 
 	ipld "github.com/ipfs/go-ipld"
@@ -24,7 +23,7 @@ func init() {
 	defaultCodec = string(mc.HeaderPath(mccbor.Header))
 	muxCodec = mcmux.MuxMulticodec([]mc.Multicodec{
 		mccbor.Multicodec(),
-		mcjson.Multicodec(false),
+		jsonMulticodec(),
 		pb.Multicodec(),
 	}, selectCodec)
 }
@@ -61,8 +60,6 @@ func codecKey(n ipld.Node) (string, error) {
 	if !ok {
 		// if no codec is defined, use our default codec
 		chdr = defaultCodec
-
-		// except, if it looks like an old, style protobuf object
 		if pb.IsOldProtobufNode(n) {
 			chdr = string(pb.Header)
 		}

--- a/coding/json.go
+++ b/coding/json.go
@@ -1,0 +1,71 @@
+package ipfsld
+
+import (
+	"io"
+
+	mc "github.com/jbenet/go-multicodec"
+	mcjson "github.com/jbenet/go-multicodec/json"
+	ipld "github.com/ipfs/go-ipld"
+)
+
+type codec struct {
+	mc.Multicodec
+}
+
+type decoder struct {
+	mc.Decoder
+}
+
+func jsonMulticodec() mc.Multicodec {
+	return &codec{mcjson.Multicodec(false)}
+}
+
+func (c *codec) Decoder(r io.Reader) mc.Decoder {
+	return &decoder{ c.Multicodec.Decoder(r) }
+}
+
+func (c *decoder) Decode(v interface{}) error {
+	err := c.Decoder.Decode(v)
+	if err == nil {
+		convert(v)
+	}
+	return err
+}
+
+func convert(val interface{}) interface{} {
+	switch val.(type) {
+	case *map[string]interface{}:
+		vmi := val.(*map[string]interface{})
+		n := ipld.Node{}
+		for k, v := range *vmi {
+			n[k] = convert(v)
+			(*vmi)[k] = convert(v)
+		}
+		return &n
+	case map[string]interface{}:
+		vmi := val.(map[string]interface{})
+		n := ipld.Node{}
+		for k, v := range vmi {
+			n[k] = convert(v)
+			vmi[k] = convert(v)
+		}
+		return n
+	case *[]interface{}:
+		convert(*val.(*[]interface{}))
+	case []interface{}:
+		slice := val.([]interface{})
+		for k, v := range slice {
+			slice[k] = convert(v)
+		}
+	case *ipld.Node:
+		convert(*val.(*ipld.Node))
+	case ipld.Node:
+		n := val.(ipld.Node)
+		for k, v := range n {
+			n[k] = convert(v)
+		}
+	default:
+	}
+	return val
+}
+

--- a/coding/json.testfile
+++ b/coding/json.testfile
@@ -1,0 +1,3 @@
+/multicodec
+/json
+{"@codec":"/json","abc":{"mlink":"QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V"}}


### PR DESCRIPTION
I tried to test that decoding JSON actually worked and we could get links from it, and it failed. The problem was that the link object was a `map[string]interface{}` and not a `Node`. This was the issue described in issue #3, perhaps we should reopen it as there is likely a similar issue with cbor.
