### PR TITLE
Test CBOR decoding and fix implementation

### DIFF
--- a/coding/Makefile
+++ b/coding/Makefile
@@ -2,9 +2,18 @@
 pb/bin/multicodec:
 	$(MAKE) -C pb bin/multicodec
 
+bin/convert:
+	cd bin; go build convert.go
+
 json.testfile: pb/bin/multicodec Makefile
 	: >$@
 	pb/bin/multicodec header /multicodec >>$@
 	pb/bin/multicodec header /json >>$@
 	echo '{"@codec":"/json","abc":{"mlink":"QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V"}}' >>$@
+
+cbor.testfile: json.testfile
+	pb/bin/multicodec header /multicodec >$@
+	./convert -i $< -o $@.tmp -c '/cbor'
+	cat $@.tmp >>$@
+	rm -f $@.tmp
 

--- a/coding/bin/convert.go
+++ b/coding/bin/convert.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"io/ioutil"
+	"flag"
+	"os"
+
+	mc "github.com/jbenet/go-multicodec"
+	pb "github.com/ipfs/go-ipld/coding/pb"
+	ipld "github.com/ipfs/go-ipld"
+	coding "github.com/ipfs/go-ipld/coding"
+)
+
+var codecs []mc.Multicodec = []mc.Multicodec{
+	coding.CborMulticodec(),
+	coding.JsonMulticodec(),
+	pb.Multicodec(),
+}
+
+func codecByName(name string) mc.Multicodec {
+	for _, c := range codecs {
+		if name == string(mc.HeaderPath(c.Header())) {
+			return c
+		}
+	}
+	return nil
+}
+
+func main() {
+	infile  := flag.String("i", "", "Input file")
+	outfile := flag.String("o", "", "Output file")
+	codecid := flag.String("c", "", "Multicodec to use")
+	flag.Parse()
+	file, err := ioutil.ReadFile(*infile)
+	if err != nil {
+		panic(err)
+	}
+
+	var n ipld.Node
+	codec := coding.Multicodec()
+
+	if err := mc.Unmarshal(codec, file, &n); err != nil {
+		panic(err)
+	}
+
+	codec = codecByName(*codecid)
+	if codec == nil {
+		panic("Could not find codec " + *codecid)
+	}
+
+	delete(n, ipld.CodecKey)
+
+	encoded, err := mc.Marshal(codec, &n)
+	if err != nil {
+		panic(err)
+	}
+
+	f, err := os.Create(*outfile)
+	if err != nil {
+		panic(err)
+	}
+	defer f.Close()
+
+	_, err = f.Write(encoded);
+	if err != nil {
+		panic(err)
+	}
+}
+
+

--- a/coding/cbor.testfile
+++ b/coding/cbor.testfile
@@ -1,0 +1,3 @@
+/multicodec
+/cbor
+¡cabc¡emlinkx.QmXg9Pp2ytZ14xgmQjYEiHjVjMFXzCVVEcRTWJBmLgR39V

--- a/coding/coding.go
+++ b/coding/coding.go
@@ -22,8 +22,8 @@ func init() {
 	// by default, always encode things as cbor
 	defaultCodec = string(mc.HeaderPath(mccbor.Header))
 	muxCodec = mcmux.MuxMulticodec([]mc.Multicodec{
-		mccbor.Multicodec(),
-		jsonMulticodec(),
+		CborMulticodec(),
+		JsonMulticodec(),
 		pb.Multicodec(),
 	}, selectCodec)
 }

--- a/coding/transform.go
+++ b/coding/transform.go
@@ -5,26 +5,31 @@ import (
 
 	mc "github.com/jbenet/go-multicodec"
 	mcjson "github.com/jbenet/go-multicodec/json"
+	mccbor "github.com/jbenet/go-multicodec/cbor"
 	ipld "github.com/ipfs/go-ipld"
 )
 
-type codec struct {
+type transformCodec struct {
 	mc.Multicodec
 }
 
-type decoder struct {
+type transformDecoder struct {
 	mc.Decoder
 }
 
-func jsonMulticodec() mc.Multicodec {
-	return &codec{mcjson.Multicodec(false)}
+func JsonMulticodec() mc.Multicodec {
+	return &transformCodec{mcjson.Multicodec(false)}
 }
 
-func (c *codec) Decoder(r io.Reader) mc.Decoder {
-	return &decoder{ c.Multicodec.Decoder(r) }
+func CborMulticodec() mc.Multicodec {
+	return &transformCodec{mccbor.Multicodec()}
 }
 
-func (c *decoder) Decode(v interface{}) error {
+func (c *transformCodec) Decoder(r io.Reader) mc.Decoder {
+	return &transformDecoder{ c.Multicodec.Decoder(r) }
+}
+
+func (c *transformDecoder) Decode(v interface{}) error {
 	err := c.Decoder.Decode(v)
 	if err == nil {
 		convert(v)
@@ -48,6 +53,26 @@ func convert(val interface{}) interface{} {
 		for k, v := range vmi {
 			n[k] = convert(v)
 			vmi[k] = convert(v)
+		}
+		return n
+	case *map[interface{}]interface{}:
+		vmi := val.(*map[interface{}]interface{})
+		n := ipld.Node{}
+		for k, v := range *vmi {
+			if k2, ok := k.(string); ok {
+				n[k2] = convert(v)
+				(*vmi)[k2] = convert(v)
+			}
+		}
+		return &n
+	case map[interface{}]interface{}:
+		vmi := val.(map[interface{}]interface{})
+		n := ipld.Node{}
+		for k, v := range vmi {
+			if k2, ok := k.(string); ok {
+				n[k2] = convert(v)
+				vmi[k2] = convert(v)
+			}
 		}
 		return n
 	case *[]interface{}:


### PR DESCRIPTION
Same as d68f39de9a4acb036fcba7c9c6a8af2c17563b3a but for CBOR.

Add a test that decodes a CBOR object, and detect links in it. Then encode
it again and it must match the original file. The test failed (because the
link was a map[interface{}]interface{} instead of a Node). The fix
post-process the result of the CBOR decoder to convert
map[interface{}]interface{} to Node.
